### PR TITLE
Fix Issue "Address Form auto fill not working on IE11"

### DIFF
--- a/src/view/frontend/templates/edit.phtml
+++ b/src/view/frontend/templates/edit.phtml
@@ -152,6 +152,23 @@
     }
 </script>
 <script>
+    // polyfill the CustomEvent() 
+    (function () {
+
+      if ( typeof window.CustomEvent === "function" ) return false;
+
+      function CustomEvent ( event, params ) {
+        params = params || { bubbles: false, cancelable: false, detail: undefined };
+        var evt = document.createEvent( 'CustomEvent' );
+        evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+        return evt;
+       }
+
+      CustomEvent.prototype = window.Event.prototype;
+
+      window.CustomEvent = CustomEvent;
+    })();
+    
     var placeSearch, autocomplete;
     var componentForm = {
         street_number: 'short_name',
@@ -220,7 +237,7 @@
                     var elementId = lookupElement[addressType];
                     document.getElementById(elementId).value = val;
                     if(addressType == 'country') {
-                        document.getElementById(elementId).dispatchEvent(new Event('change'));
+                        document.getElementById(elementId).dispatchEvent(new window.CustomEvent('change'));
                     }
                 }
             }


### PR DESCRIPTION
Fix Issue ["Address Form auto fill not working on IE11"](https://github.com/shipperhq/module-address-autocomplete/issues/2)

 - Add Polyfill the CustomEvent() constructor functionality in Internet Explorer 9 and higher