### PR TITLE
Update US Street Address Format

### DIFF
--- a/src/view/frontend/web/js/autocomplete.js
+++ b/src/view/frontend/web/js/autocomplete.js
@@ -188,7 +188,7 @@ define(
                 var streetString = street.join(' ');
 
                 if (countryId === 'US') {
-                    streetString += ', ' + subpremise
+                    streetString += ' ' + subpremise
                 }
 
                 if ($('#' + domID).length) {


### PR DESCRIPTION
In the US, the address format typically follows this structure: 
[Street Address] [Subpremise]
[City], [State] [Postal Code]

There is usually no comma between the street address and the subpremise.  The comma is used to separate the city from the state. When selecting an address from the autocomplete, the module appends the comma to the end of the street1 field:

<img width="623" alt="Screenshot 2024-05-08 at 4 36 00 PM" src="https://github.com/shipperhq/module-address-autocomplete/assets/169086526/966aeff4-f0e7-40fa-b4d2-04eacd76a230">

 This PR, removes the comma between the street and subpremise in the fillInAddress function.

<img width="645" alt="Screenshot 2024-05-08 at 4 35 22 PM" src="https://github.com/shipperhq/module-address-autocomplete/assets/169086526/66237ea2-0b90-4d69-b616-21445bf1aa6a">